### PR TITLE
Fix: missing comma in target_modules drops feed_forward.w1/w2 from LoRA

### DIFF
--- a/z-image-turbo_self-distill-vlm/train_dopsd.py
+++ b/z-image-turbo_self-distill-vlm/train_dopsd.py
@@ -234,7 +234,7 @@ def main(args):
     if args.use_lora > 1:
         # Set correct lora layers
         target_modules = [
-            "feed_forward.w1"
+            "feed_forward.w1",
             "feed_forward.w2",
             "feed_forward.w3",
             "attention.to_k",


### PR DESCRIPTION
## What

`train_dopsd.py` line 237 is missing a trailing comma:

```python
target_modules = [
    "feed_forward.w1"     # ← missing comma
    "feed_forward.w2",
    ...
]
```

Python silently concatenates the two adjacent string literals into the single string `"feed_forward.w1feed_forward.w2"`, which matches no module in the Z-Image DiT. PEFT then applies LoRA to `feed_forward.w3` and the four attention projections only, silently skipping `feed_forward.w1` (gate) and `feed_forward.w2` (up-projection).

## How to confirm

After training with `--use-lora 2`, inspect the generated `adapter_config.json`. The `target_modules` field contains the literal nonsense string verbatim:

```json
"target_modules": [
    "feed_forward.w1feed_forward.w2",
    "feed_forward.w3",
    "attention.to_out.0",
    "attention.to_v",
    "attention.to_q",
    "attention.to_k"
]
```

## Impact

5 of 7 intended modules per transformer block get LoRA adapters instead of 7. Roughly 30% of the intended FFN coverage is lost (the gate + up-projection feeding into the down-projection are not adapted). Trained LoRAs still work — attention adapts strongly for identity/style and `w3` injects FFN-side delta — but capacity is below the recipe.

## Fix

One-character change: add the missing comma.